### PR TITLE
Allow importing time at the project-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Toggle 2 Redmine
+# Toggl 2 Redmine
 
 ![Redmine Version](https://img.shields.io/badge/Redmine-4.x-green.svg)
 

--- a/app/controllers/t2r_base_controller.rb
+++ b/app/controllers/t2r_base_controller.rb
@@ -30,6 +30,12 @@ class T2rBaseController < ApplicationController
     user_is_member_of?(@user, issue.project)
   end
 
+  def user_can_view_project?(project)
+    return true if @user.admin?
+    
+    user_is_member_of?(@user, project)
+  end
+
   def user_is_member_of?(user, project)
     Member.where(user: user, project: project).count.positive?
   end

--- a/app/controllers/t2r_import_controller.rb
+++ b/app/controllers/t2r_import_controller.rb
@@ -78,7 +78,7 @@ class T2rImportController < T2rBaseController
         )
       te.assign_attributes(attributes)
       te.user = @user
-      te.project = te.issue&.project
+      te.project = te&.issue&.project || Project.find_by_id(params.dig(:project_info, :id))
       te.validate!
     end
   end

--- a/app/models/toggl_time_entry.rb
+++ b/app/models/toggl_time_entry.rb
@@ -37,8 +37,8 @@ class TogglTimeEntry
 
   # Finds the most aproximate associated Redmine project if applicable
   def redmine_project
-    #Project.where("lower(identifier) LIKE ?", "%#{@pid_name.downcase}%")
-    Project.where("lower(name) = ?", @pid_name.downcase)
+    # Project.where("trim(lower(identifier)) = ?", @pid_name.downcase.strip)
+    Project.where("trim(lower(name)) = ?", @pid_name.downcase.strip)
   end
 
   # Gets the status of the entry.

--- a/app/models/toggl_time_entry.rb
+++ b/app/models/toggl_time_entry.rb
@@ -4,11 +4,14 @@
 class TogglTimeEntry
   include ActiveModel::Model
 
-  attr_reader :id, :wid, :issue_id, :duration, :at, :comments
+  attr_reader :id, :wid, :pid, :pid_name, :issue_id, :duration, :at, :comments
 
   def initialize(attributes = {})
+
     @id = attributes[:id].to_i
     @wid = attributes[:wid].to_i
+    @pid = attributes[:pid].to_i
+    @pid_name = attributes[:pid_name].to_s
     @duration = attributes[:duration].to_i
     @at = attributes[:at]
     @issue_id = nil
@@ -21,6 +24,7 @@ class TogglTimeEntry
   def key
     [
       (@issue_id || 0).to_s,
+      (@pid || 0).to_s,
       @comments.to_s.downcase,
       status
     ].join(':')
@@ -29,6 +33,12 @@ class TogglTimeEntry
   # Finds the associated Redmine issue.
   def issue
     Issue.find_by(id: @issue_id)
+  end
+
+  # Finds the most aproximate associated Redmine project if applicable
+  def redmine_project
+    #Project.where("lower(identifier) LIKE ?", "%#{@pid_name.downcase}%")
+    Project.where("lower(name) = ?", @pid_name.downcase)
   end
 
   # Gets the status of the entry.
@@ -58,6 +68,8 @@ class TogglTimeEntry
     TogglTimeEntry === other &&
       @id == other.id &&
       @wid == other.wid &&
+      @pid == other.pid &&
+      @pid_name == other.pid_name &&
       @duration == other.duration &&
       @at == other.at &&
       @issue_id == other.issue_id &&
@@ -67,12 +79,17 @@ class TogglTimeEntry
   private
 
   # Parses a Toggl description and returns its components.
+  # If the parses fails but there is an associated project id, try do group by the project and comment
   def parse_description(description)
     matches = description.to_s.strip.scan(/^[^#]*#+(\d+)\s*(.*)?$/).first
-    return unless matches&.count == 2
-
-    @issue_id = matches[0].to_i
-    @comments = matches[1]
+    if matches&.count == 2 then
+      @issue_id = matches[0].to_i
+      @comments = matches[1]  
+    elsif @pid > 0
+      @comments = description.to_s.strip
+    else
+      return
+    end
   end
 
   # Finds the associated Toggl mapping.

--- a/app/models/toggl_time_entry_group.rb
+++ b/app/models/toggl_time_entry_group.rb
@@ -22,8 +22,20 @@ class TogglTimeEntryGroup
     @entries.values.first&.issue_id
   end
 
+  def pid
+    @entries.values.first&.pid
+  end
+
+  def pid_name
+    @entries.values.first&.pid_name
+  end
+
   def issue
-    @entries.values.first&.issue
+    @entries.values.first&.issue()
+  end
+
+  def redmine_project
+    @entries.values.first&.redmine_project()
   end
 
   def comments
@@ -43,7 +55,7 @@ class TogglTimeEntryGroup
   end
 
   def <<(entry)
-    unless TogglTimeEntry === entry
+    if !(TogglTimeEntry === entry)
       raise ArgumentError, "Argument must be a #{TogglTimeEntry.name}"
     end
 
@@ -71,7 +83,9 @@ class TogglTimeEntryGroup
       issue_id: issue_id,
       comments: comments,
       duration: duration,
-      status: status
+      status: status,
+      pid: pid,
+      pid_name: pid_name
     }
   end
 

--- a/app/views/t2r_import/index.html.erb
+++ b/app/views/t2r_import/index.html.erb
@@ -82,7 +82,7 @@
     <a aria-role="button" href="#" id="btn-apply-filters"
        class="icon icon-checked"><%= t :button_apply %></a>
     <a aria-role="button" href="#" id="btn-reset-filters"
-       class="icon icon-reload"><%= t :button_reset %></a>
+      class="icon icon-reload"><%= t :button_reset %></a>
     <a aria-role="button" href="https://github.com/jigarius/toggl2redmine#usage"
        target="_blank" id="btn-help" class="icon icon-help"
        title="<%= t 't2r.tooltip_help' %>"><%= t 't2r.button_help' %></a>

--- a/app/views/t2r_import/index.html.erb
+++ b/app/views/t2r_import/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Toggle 2 Redmine <span class="date"></span></h2>
+<h2>Toggl 2 Redmine <span class="date"></span></h2>
 
 <form id="filter-form" class="t2r-form">
   <fieldset class="collapsible" id="basic-options">

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -846,7 +846,7 @@ T2R.getTogglTimeEntries = function (opts, callback) {
           entry.errors.push('Could not determine issue ID and there is no project attached to this timeentry. Please mention the Redmine issue ID in your Toggl task description. Example: "#1919 Feed the bunny wabbit"');
         }
         else if (entry.project == null){
-          entry.errors.push('The toggle project especified for this TimeEntry does not have an exact match in the Redmine projects that you have access');
+          entry.errors.push('The toggl project especified for this TimeEntry does not have an exact match in the Redmine projects that you have access');
         }
       }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
     label_last_imported: 'Last imported on %{date}'
     label_status: 'Status'
     text_add_toggl_api_key: 'To use Toggl 2 Redmine, please add a Toggl API Token to your account.'
-    text_db_transaction_warning: 'Your database does not support transactions. Please ask your system administrator to refer to the README for Toggle 2 Redmine.'
+    text_db_transaction_warning: 'Your database does not support transactions. Please ask your system administrator to refer to the README for Toggl 2 Redmine.'
     tooltip_date_filter: 'Choose the date for which you want to import time entries.'
     tooltip_duration_rounding_logic: 'Choose a logic for rounding Toggl durations.'
     tooltip_duration_rounding_value: 'All time entries from Toggl will be rounded to this number (minutes).'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
     label_status: 'Estado'
     label_last_imported: 'Última importación el %{date}'
     text_add_toggl_api_key: 'Para usar Toggl 2 Redmine, agregue su clave de API de Toggl a su cuenta.'
-    text_db_transaction_warning: 'Su base de datos no permite transacciones. Pídale al administrador del sistema que consulte el archivo README de Toggle 2 Redmine.'
+    text_db_transaction_warning: 'Su base de datos no permite transacciones. Pídale al administrador del sistema que consulte el archivo README de Toggl 2 Redmine.'
     tooltip_date_filter: 'Eliga la fecha por la que desea importar registros de tiempo.'
     tooltip_duration_rounding_logic: 'Elija la lógica para el redondeo de duraciones.'
     tooltip_duration_rounding_value: 'Todos los registros de tiempo de Toggl se redondearán a este número (minutos).'


### PR DESCRIPTION
Good morning,

I've made a change that makes possible to log time directly on the projects instead of only in the issue, and for that it is only needed to have on toggl a project that is an exact match with the name of the project on redmine.

This is a modification I've made for an use case in my corporation, and I hope this could help you all as well.

This was tested internally by my company and until now we have found no bugs, but let me know if you all find any.

Best regards,
Piradata