### PR TITLE
Update Rakefile and some other dev env stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Run `rake info` to learn how to access your demo installation!
 
 Thanks to the Docker setup, the plugin code can easily be linted and tested.
 
-  * `rake rubocop`: Run Rubocop.
-  * `rake reset RAILS_ENV=test`: Prepare/reset the test environment.
-  * `rake test`: Run tests.
+* `rake reset RAILS_ENV=test`: Prepare/reset the test environment.
+* `rake lint`: Run Rubocop.
+* `rake test`: Run tests.
 
 ### Mailhog
 

--- a/Rakefile
+++ b/Rakefile
@@ -92,8 +92,8 @@ task :info do
   INFO
 end
 
-desc 'Run Rubocop.'
-task :rubocop do
+desc 'Lint with Rubocop.'
+task :lint do
   sh 'docker compose exec redmine rubocop -c plugins/toggl2redmine/.rubocop.yml plugins/toggl2redmine'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :ssh, [:service] do |_t, args|
     service: 'redmine',
     rails_env: ENV.fetch('RAILS_ENV', 'development')
   )
-  sh "docker compose exec -e RAILS_ENV='#{args.rails_env}' #{args.service} bash"
+  sh "docker compose exec -e RAILS_ENV=#{args.rails_env} #{args.service} bash"
 end
 
 desc 'Execute a Rails command'
@@ -46,7 +46,7 @@ task :reset do
   # If all commands are sent at once, redmine:plugins:migrate fails.
   # Hence, the commands are being sent separately.
   commands.each do |command|
-    sh "docker compose exec -e RAILS_ENV='#{rails_env}' redmine rake #{command}"
+    sh "docker compose exec -e RAILS_ENV=#{rails_env} redmine rake #{command}"
   end
 
   puts "The env '#{rails_env}' has been reset."
@@ -111,5 +111,5 @@ task :test do
       "redmine:plugins:test#{type} NAME=toggl2redmine"
     end
 
-  sh "docker compose exec -e RAILS_ENV='test' redmine rake #{command}"
+  sh "docker compose exec -e RAILS_ENV=test redmine rake #{command}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ end
 
 desc 'Run Rubocop.'
 task :rubocop do
-  sh 'docker compose exec redmine rubocop plugins/toggl2redmine'
+  sh 'docker compose exec redmine rubocop -c plugins/toggl2redmine/.rubocop.yml plugins/toggl2redmine'
 end
 
 desc 'Run all or a specific test.'

--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,7 @@ task :mysql do |_t, args|
     pass: 'root',
     rails_env: ENV.fetch('RAILS_ENV', 'development')
   )
-  sh 'docker compose exec mysql mysql' \
-      " -u#{args.user} -p#{args.pass} redmine_#{args.rails_env}"
+  sh "docker compose exec mysql mysql -u#{args.user} -p#{args.pass} redmine_#{args.rails_env}"
 end
 
 desc 'Reset the database.'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       MYSQL_USER: redmine
       MYSQL_PASSWORD: redmine
     command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
+    ports:
+      - '3306:3306'
     volumes:
       - ./.docker/mysql/init:/docker-entrypoint-initdb.d
   mailhog:


### PR DESCRIPTION
## What's done

* Rename `rake prepare` to `rake provision`
* Rename `rake rubocop` to `rake lint`
* Expose MySQL port for use with apps like JetBrains DataGrip
* Specify `-c /path/to/.rubocop.yml` in `Rakefile`
  * Without this `rake lint` uses the Rubocop config file that comes with Redmine and fails.