### PR TITLE
Disallow logging time on closed projects; fixes #62

### DIFF
--- a/app/controllers/t2r_import_controller.rb
+++ b/app/controllers/t2r_import_controller.rb
@@ -86,7 +86,8 @@ class T2rImportController < T2rBaseController
   end
 
   def import_check_permissions
-    return if @user.admin? || @time_entry.project.nil?
+    # If there's no project, we cannot check permissions.
+    return unless @time_entry.project
 
     unless user_is_member_of?(@user, @time_entry.project)
       raise MembershipError, 'You are not a member of this project.'

--- a/app/models/toggl_time_entry_group.rb
+++ b/app/models/toggl_time_entry_group.rb
@@ -71,7 +71,8 @@ class TogglTimeEntryGroup
       issue_id: issue_id,
       comments: comments,
       duration: duration,
-      status: status
+      status: status,
+      errors: []
     }
   end
 

--- a/app/models/toggl_time_entry_group.rb
+++ b/app/models/toggl_time_entry_group.rb
@@ -64,6 +64,12 @@ class TogglTimeEntryGroup
     @entries.values
   end
 
+  def errors
+    result = []
+    result << I18n.t('t2r.error.project_closed') if issue&.project&.closed?
+    result
+  end
+
   def to_hash
     {
       key: key,
@@ -72,7 +78,7 @@ class TogglTimeEntryGroup
       comments: comments,
       duration: duration,
       status: status,
-      errors: []
+      errors: errors
     }
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,3 +33,4 @@ en:
     error:
       ajax_load: 'Could not retrieve data from server. Please refresh the page to try again.'
       list_empty: 'There are no items to display here.'
+      project_closed: 'The project is closed.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,3 +30,4 @@ es:
     error:
       ajax_load: 'No se pudieron leer los datos del servidor. Actualice la página para volver a intentarlo.'
       list_empty: 'No hay elementos para mostrar aquí.'
+      project_closed: 'El proyecto está cerrado.'

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -1,6 +1,5 @@
 alpha_001:
   subject: 'Abstract apples'
-  description: John Smith is a 'Manager' of project 'Alpha'.
   author: admin
   project: alpha
   tracker: task
@@ -11,7 +10,6 @@ alpha_001:
 
 alpha_002:
   subject: 'Boil bananas'
-  description: John Smith is a 'Manager' of project 'Alpha'.
   author: admin
   project: alpha
   tracker: task
@@ -22,7 +20,6 @@ alpha_002:
 
 bravo_001:
   subject: 'Condition cherries'
-  description: John Smith is a 'Reviewer' of project 'Bravo'.
   author: admin
   project: bravo
   tracker: task
@@ -33,7 +30,6 @@ bravo_001:
 
 bravo_002:
   subject: 'Dismantle dates'
-  description: John Smith is a 'Reviewer' of project 'Bravo'.
   author: admin
   project: bravo
   tracker: task
@@ -44,7 +40,6 @@ bravo_002:
 
 charlie_001:
   subject: 'Extract essence'
-  description: John Smith is not a member of project 'Charlie'.
   author: admin
   project: charlie
   tracker: task

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -47,3 +47,14 @@ charlie_001:
   status: open
   lft: 9
   rgt: 10
+
+
+delta_001:
+  subject: 'Make perfume'
+  author: admin
+  project: delta
+  tracker: task
+  priority: priority_normal
+  status: open
+  lft: 9
+  rgt: 10

--- a/test/fixtures/members.yml
+++ b/test/fixtures/members.yml
@@ -9,3 +9,9 @@ jsmith_bravo:
   project: bravo
   roles:
     - reviewer
+
+jsmith_charlie:
+  user: jsmith
+  project: charlie
+  roles:
+    - manager

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -17,10 +17,10 @@ bravo:
 charlie:
   identifier: charlie
   name: Project charlie
-  description: John Smith doesn't have access to this project.
+  description: John Smith has 'manager' access to this project, but the project is closed.
   lft: 5
   rgt: 6
-  status: 0
+  status: 5  # Project.STATUS_CLOSED
 
 delta:
   identifier: delta

--- a/test/integration/t2r_base_controller_test.rb
+++ b/test/integration/t2r_base_controller_test.rb
@@ -9,7 +9,7 @@ class T2rTestController < T2rBaseController
 end
 
 class T2rBaseControllerTest < T2r::IntegrationTest
-  fixtures :custom_fields, :users
+  fixtures :all
 
   def setup
     @user = users(:jsmith)

--- a/test/integration/t2r_import_controller_test.rb
+++ b/test/integration/t2r_import_controller_test.rb
@@ -96,7 +96,7 @@ class T2rImportControllerTest < T2r::IntegrationTest
         activity_id: enumerations(:activity_development).id,
         comments: 'Special delivery!',
         hours: 4.0,
-        issue_id: issues(:charlie_001).id,
+        issue_id: issues(:delta_001).id,
         spent_on: '2021-01-17'
       }
     }

--- a/test/integration/t2r_import_controller_test.rb
+++ b/test/integration/t2r_import_controller_test.rb
@@ -152,6 +152,27 @@ class T2rImportControllerTest < T2r::IntegrationTest
     )
   end
 
+  test '.import returns 400 response if the project is closed' do
+    data = {
+      toggl_ids: [50],
+      time_entry: {
+        activity_id: enumerations(:activity_other).id,
+        comments: 'Organize party for the year 2020',
+        hours: 4,
+        issue_id: issues(:charlie_001).id,
+        spent_on: '2021-07-20'
+      }
+    }
+
+    post '/toggl2redmine/import', params: data
+
+    assert_response 403
+    assert_equal(
+      { 'errors' => ['You are not allowed to log time on this project.'] },
+      @response.parsed_body
+    )
+  end
+
   test '.import returns 503 response and rolls back if time entries cannot be saved' do
     data = {
       toggl_ids: [2001, 2002, 1003],

--- a/test/integration/t2r_toggl_controller_test.rb
+++ b/test/integration/t2r_toggl_controller_test.rb
@@ -223,7 +223,7 @@ class T2rTogglControllerTest < T2r::IntegrationTest
   end
 
   test ".read_time_entries returns issue as nil when user doesn't belong to the project" do
-    issue = issues(:charlie_001)
+    issue = issues(:delta_001)
 
     time_entries = [
       TogglTimeEntry.new(

--- a/test/integration/t2r_toggl_controller_test.rb
+++ b/test/integration/t2r_toggl_controller_test.rb
@@ -72,6 +72,7 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'comments' => 'Prepare food',
         'duration' => 450,
         'status' => 'pending',
+        'errors' => [],
         'issue' => nil
       },
       '19:feed bunny:running' => {
@@ -81,6 +82,7 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'comments' => 'Feed bunny',
         'duration' => -1,
         'status' => 'running',
+        'errors' => [],
         'issue' => nil
       }
     }
@@ -170,7 +172,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
             'name' => issue.project.name,
             'status' => issue.project.status
           }
-        }
+        },
+        'errors' => []
       }
     }
 
@@ -215,6 +218,7 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'comments' => 'Feed bunny',
         'duration' => 300,
         'status' => 'pending',
+        'errors' => [],
         'issue' => nil
       }
     }
@@ -262,6 +266,7 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'comments' => 'Feed bunny',
         'duration' => 300,
         'status' => 'pending',
+        'errors' => [],
         'issue' => nil
       }
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,11 @@
 require "#{Rails.root}/test/test_helper"
 
 module T2r
+  class TestCase < ActiveSupport::TestCase
+    self.fixture_path =
+      File.join(Toggl2Redmine.root, 'test', 'fixtures')
+  end
+
   class IntegrationTest < Redmine::IntegrationTest
     self.fixture_path =
       File.join(Toggl2Redmine.root, 'test', 'fixtures')

--- a/test/unit/models/toggl_time_entry_group_test.rb
+++ b/test/unit/models/toggl_time_entry_group_test.rb
@@ -3,6 +3,8 @@
 require_relative '../../test_helper'
 
 class TogglTimeEntryGroupTest < ActiveSupport::TestCase
+  fixtures :projects, :issues
+
   test '.new' do
     expected = [
       build_time_entry_record,
@@ -73,6 +75,15 @@ class TogglTimeEntryGroupTest < ActiveSupport::TestCase
 
     refute_nil(subject.status)
     assert_equal(record.status, subject.status)
+  end
+
+  test '.errors contains a message for closed project' do
+    issue = issues(:charlie_001)
+    subject = TogglTimeEntryGroup.new
+    record = build_time_entry_record(description: "##{issue.id} Lorem ipsum")
+    subject << record
+
+    assert_equal(['The project is closed.'], subject.errors)
   end
 
   test '.imported?' do

--- a/test/unit/models/toggl_time_entry_group_test.rb
+++ b/test/unit/models/toggl_time_entry_group_test.rb
@@ -2,8 +2,8 @@
 
 require_relative '../../test_helper'
 
-class TogglTimeEntryGroupTest < ActiveSupport::TestCase
-  fixtures :projects, :issues
+class TogglTimeEntryGroupTest < T2r::TestCase
+  fixtures :all
 
   test '.new' do
     expected = [

--- a/test/unit/models/toggl_time_entry_group_test.rb
+++ b/test/unit/models/toggl_time_entry_group_test.rb
@@ -160,7 +160,8 @@ class TogglTimeEntryGroupTest < ActiveSupport::TestCase
       'issue_id' => nil,
       'duration' => 0,
       'comments' => nil,
-      'status' => nil
+      'status' => nil,
+      'errors' => []
     }
 
     assert_equal(expected, subject.as_json)
@@ -181,7 +182,8 @@ class TogglTimeEntryGroupTest < ActiveSupport::TestCase
       'issue_id' => r1.issue_id,
       'duration' => r1.duration + r2.duration,
       'comments' => r1.comments,
-      'status' => r1.status
+      'status' => r1.status,
+      'errors' => []
     }
 
     assert_equal(expected, subject.as_json)


### PR DESCRIPTION
## The problem

- Users should not be allowed to log time on closed projects.
  - Even admins should be disallowed because that's the behavior we get in the Redmine UI.

## What's done

- Updated fixtures for testing this bug fix.
- Enabled membership and `:log_time` permission test for admin users.
- Fixed one test that was broken due to the change in fixtures.
- The T2R UI prevents users from importing time entries if the associated project is closed.