### PR TITLE
Round Toggl time to nearest minute by default

### DIFF
--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -1575,7 +1575,7 @@ T2RDuration.prototype.setSeconds = function (seconds) {
  *   Duration in seconds.
  */
 T2RDuration.prototype.getSeconds = function (imprecise) {
-  imprecise = 'undefined' === typeof imprecise ? false : imprecise;
+  imprecise = imprecise === true;
   var output = this.__seconds;
 
   // For imprecise output, round-down to the nearest full minute.

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -849,7 +849,19 @@ T2R.getTogglTimeEntries = function (opts, callback) {
       // Prepare rounded duration as per rounding rules.
       if (roundingDirection !== '' && roundingValue > 0) {
         entry.roundedDuration.roundTo(roundingValue, roundingDirection);
-        T2RConsole.log('Duration rounded from ' + entry.duration.asHHMM() + ' to ' + entry.roundedDuration.asHHMM());
+      }
+      else {
+        entry.roundedDuration.roundTo(1, T2RDuration.ROUND_REGULAR);
+      }
+
+      if (entry.duration.getSeconds(false) !== entry.roundedDuration.getSeconds(false)) {
+        T2RConsole.log('Duration rounded.', {
+          from: entry.duration.asHHMM(),
+          to: entry.roundedDuration.asHHMM()
+        });
+      }
+      else {
+        T2RConsole.log('Duration not rounded.', entry.duration.asHHMM());
       }
 
       // If there is no issue ID associated to the entry.
@@ -1752,7 +1764,7 @@ T2RDuration.prototype.roundTo = function (minutes, direction) {
   var seconds = minutes * 60;
 
   // Determine the amount of correction required.
-  var correction = this.getSeconds(true) % seconds;
+  var correction = this.getSeconds(false) % seconds;
 
   // Do nothing if no correction / rounding is required.
   if (correction === 0) {

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -1446,7 +1446,7 @@ T2RAjaxQueue.processItem = function () {
     return;
   }
   T2RAjaxQueue.__requestInProgress = true;
-  T2RConsole.group('Processing queue. ' + T2RAjaxQueue.size() + ' remaining.');
+  T2RConsole.group('Processing AJAX queue. ' + T2RAjaxQueue.size() + ' remaining.', true);
 
   // Prepare current item.
   var opts = T2RAjaxQueue.__items.shift();

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -1456,7 +1456,6 @@ T2RAjaxQueue.processItem = function () {
     // Call the original callback.
     var context = this;
     callback.call(context, xhr, status);
-    T2RConsole.groupEnd();
 
     // Process the next item in the queue, if any.
     T2RAjaxQueue.__requestInProgress = false;
@@ -1465,6 +1464,7 @@ T2RAjaxQueue.processItem = function () {
 
   // Process current item.
   $.ajax(opts);
+  T2RConsole.groupEnd();
 }
 
 /**


### PR DESCRIPTION
## What's done

- Round time to nearest minute by default
  - If 30s or more, round up
  - If less than 30s, round down

Fixes #59