### PR TITLE
Make project labels clickable; fixes #68

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ task :lint do
   sh 'docker compose exec redmine rubocop -c plugins/toggl2redmine/.rubocop.yml plugins/toggl2redmine'
 end
 
-desc 'Run all or a specific test.'
+desc 'Run all tests or a specific test.'
 task :test do
   file = ENV.fetch('TEST', nil)
   type = ENV.fetch('TYPE', nil)
@@ -105,7 +105,7 @@ task :test do
 
   command =
     if file
-      "test TEST=plugins/toggl2redmine/test/#{file}"
+      "test TEST=plugins/toggl2redmine/#{file}"
     else
       "redmine:plugins:test#{type} NAME=toggl2redmine"
     end

--- a/app/controllers/t2r_redmine_controller.rb
+++ b/app/controllers/t2r_redmine_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class T2rRedmineController < T2rBaseController
+  include Rails.application.routes.url_helpers
+
   def read_time_entries
     parse_params
 
@@ -10,7 +12,7 @@ class T2rRedmineController < T2rBaseController
     ).order(:id)
 
     result = time_entries.map do |time_entry|
-      time_entry.as_json(
+      item = time_entry.as_json(
         only: %i[id comments hours],
         include: {
           issue: {
@@ -23,6 +25,11 @@ class T2rRedmineController < T2rBaseController
           activity: { only: %i[id name] }
         }
       )
+
+      item['issue']['path'] = issue_path(time_entry.issue) if item['issue']
+      item['project']['path'] = project_path(time_entry.project) if item['project']
+
+      item
     end
 
     render json: { time_entries: result }

--- a/app/controllers/t2r_redmine_controller.rb
+++ b/app/controllers/t2r_redmine_controller.rb
@@ -9,8 +9,8 @@ class T2rRedmineController < T2rBaseController
       spent_on: params[:from]..params[:till]
     ).order(:id)
 
-    render json: {
-      time_entries: time_entries.as_json(
+    result = time_entries.map do |time_entry|
+      time_entry.as_json(
         only: %i[id comments hours],
         include: {
           issue: {
@@ -23,7 +23,9 @@ class T2rRedmineController < T2rBaseController
           activity: { only: %i[id name] }
         }
       )
-    }
+    end
+
+    render json: { time_entries: result }
   rescue ActionController::ParameterMissing => e
     render json: { errors: [e.message] }, status: 400
   end

--- a/app/controllers/t2r_toggl_controller.rb
+++ b/app/controllers/t2r_toggl_controller.rb
@@ -11,10 +11,9 @@ class T2rTogglController < T2rBaseController
       end_date: params[:till],
       workspaces: params[:workspaces]
     )
-    time_entry_groups = TogglTimeEntryGroup.group(time_entries)
+    groups = TogglTimeEntryGroup.group(time_entries)
 
-    result = {}
-    time_entry_groups.each do |key, group|
+    result = groups.merge(groups) do |_, group|
       item = group.as_json
       item['issue'] = nil
       item['project'] = nil
@@ -35,7 +34,7 @@ class T2rTogglController < T2rBaseController
         item['project']['path'] = project_path(group.project)
       end
 
-      result[key] = item
+      item
     end
 
     render json: result

--- a/app/controllers/t2r_toggl_controller.rb
+++ b/app/controllers/t2r_toggl_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class T2rTogglController < T2rBaseController
+  include Rails.application.routes.url_helpers
+
   def read_time_entries
     parse_params
 
@@ -13,12 +15,12 @@ class T2rTogglController < T2rBaseController
 
     result = {}
     time_entry_groups.each do |key, group|
-      result[key] = group.as_json
-      result[key]['issue'] = nil
-      result[key]['project'] = nil
+      item = group.as_json
+      item['issue'] = nil
+      item['project'] = nil
 
       if group.issue && user_can_view_issue?(group.issue)
-        result[key]['issue'] =
+        item['issue'] =
           group.issue.as_json(
             only: %i[id subject],
             include: {
@@ -28,9 +30,12 @@ class T2rTogglController < T2rBaseController
       end
 
       if group.project && user_is_member_of?(@user, group.project)
-        result[key]['project'] =
+        item['project'] =
           group.project.as_json(only: %i[id name status])
+        item['project']['path'] = project_path(group.project)
       end
+
+      result[key] = item
     end
 
     render json: result

--- a/app/models/toggl_time_entry_group.rb
+++ b/app/models/toggl_time_entry_group.rb
@@ -26,6 +26,10 @@ class TogglTimeEntryGroup
     @entries.values.first&.issue
   end
 
+  def project
+    issue&.project
+  end
+
   def comments
     @entries.values.first&.comments
   end

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -2203,6 +2203,18 @@ T2RRenderer.renderDuration = function (data) {
   return output;
 };
 
+T2RRenderer.renderRedmineProjectLabel = function (project) {
+  project ||= { name: 'Unknown', path: 'javascript:void(0)', status: 1 };
+  project.classes = ['project'];
+  if (project.status != 1) {
+    project.classes.push('closed');
+  }
+
+  return '<a href="' + project.path + '" class="' + project.classes.join(' ') + '"><strong>'
+      + T2R.htmlEntityEncode(project.name)
+      + '</strong></a>';
+}
+
 T2RRenderer.renderRedmineIssueLabel = function (data) {
   // If the issue is invalid, do nothing.
   var issue = data;
@@ -2220,7 +2232,8 @@ T2RRenderer.renderRedmineIssueLabel = function (data) {
 };
 
 T2RRenderer.renderTogglRow = function (data) {
-  var issue = data.issue || false;
+  var issue = data.issue || null;
+  var project = data.project || null;
   var oDuration = data.duration;
   var rDuration = data.roundedDuration;
 
@@ -2235,7 +2248,7 @@ T2RRenderer.renderTogglRow = function (data) {
     + '<td class="status"></td>'
     + '<td class="issue">'
       + '<input data-property="issue_id" type="hidden" data-value="' + T2R.htmlEntityEncode(issue ? issue.id : '') + '" value="' + issue.id + '" />'
-      + '<strong>' + T2R.htmlEntityEncode(issue ? issue.project.name : 'Unknown') + '</strong>'
+      + T2RRenderer.render('RedmineProjectLabel', project)
       + '<br />'
       + issueLabel
     + '</td>'
@@ -2304,14 +2317,15 @@ T2RRenderer.renderTogglRow = function (data) {
 };
 
 T2RRenderer.renderRedmineRow = function (data) {
-  var issue = data.issue.id ? data.issue : false;
+  var issue = data.issue.id ? data.issue : null;
+  var project = data.project ? data.project : null;
 
   // Build a label for the issue.
   var issueLabel = issue ? T2RRenderer.render('RedmineIssueLabel', issue) : '-';
 
   var markup = '<tr id="time-entry-' + data.id + '"  class="time-entry hascontextmenu">'
     + '<td class="subject">'
-      + '<strong>' + T2R.htmlEntityEncode(data.project.name || 'Unknown') + '</strong>'
+      + T2RRenderer.render('RedmineProjectLabel', project)
       + '<br />'
       + issueLabel
       + '<input type="checkbox" name="ids[]" value="' + data.id + '" hidden />'

--- a/assets/javascripts/t2r.js
+++ b/assets/javascripts/t2r.js
@@ -2247,7 +2247,7 @@ T2RRenderer.renderTogglRow = function (data) {
     + '<td class="checkbox"><input class="cb-import" type="checkbox" value="1" title="Check this box if you want to import this entry." /></td>'
     + '<td class="status"></td>'
     + '<td class="issue">'
-      + '<input data-property="issue_id" type="hidden" data-value="' + T2R.htmlEntityEncode(issue ? issue.id : '') + '" value="' + issue.id + '" />'
+      + '<input data-property="issue_id" type="hidden" data-value="' + T2R.htmlEntityEncode(issue ? issue.id : '') + '" value="' + (issue ? issue.id : '') + '" />'
       + T2RRenderer.render('RedmineProjectLabel', project)
       + '<br />'
       + issueLabel

--- a/test/integration/t2r_redmine_controller_test.rb
+++ b/test/integration/t2r_redmine_controller_test.rb
@@ -3,9 +3,9 @@
 require_relative '../test_helper'
 
 class T2rRedmineControllerTest < T2r::IntegrationTest
-  make_my_diffs_pretty!
-
+  include Rails.application.routes.url_helpers
   fixtures :all
+  make_my_diffs_pretty!
 
   def setup
     @user = users(:jsmith)
@@ -41,9 +41,15 @@ class T2rRedmineControllerTest < T2r::IntegrationTest
           'issue' => {
             'id' => e3.issue.id,
             'subject' => 'Boil bananas',
-            'tracker' => { 'id' => e3.issue.tracker.id, 'name' => 'Task' }
+            'tracker' => { 'id' => e3.issue.tracker.id, 'name' => 'Task' },
+            'path' => issue_path(e3.issue)
           },
-          'project' => { 'id' => e3.project.id, 'name' => 'Project alpha', 'status' => 1 },
+          'project' => {
+            'id' => e3.project.id,
+            'name' => 'Project alpha',
+            'status' => 1,
+            'path' => project_path(e3.project)
+          },
           'activity' => { 'id' => e3.activity.id, 'name' => 'Development' }
         },
         {
@@ -53,9 +59,15 @@ class T2rRedmineControllerTest < T2r::IntegrationTest
           'issue' => {
             'id' => e4.issue.id,
             'subject' => 'Condition cherries',
-            'tracker' => { 'id' => e4.issue.tracker.id, 'name' => 'Task' }
+            'tracker' => { 'id' => e4.issue.tracker.id, 'name' => 'Task' },
+            'path' => issue_path(e4.issue)
           },
-          'project' => { 'id' => e4.project.id, 'name' => 'Project bravo', 'status' => 1 },
+          'project' => {
+            'id' => e4.project.id,
+            'name' => 'Project bravo',
+            'status' => 1,
+            'path' => project_path(e4.project)
+          },
           'activity' => { 'id' => e4.activity.id, 'name' => 'Other' }
         },
         {
@@ -65,9 +77,15 @@ class T2rRedmineControllerTest < T2r::IntegrationTest
           'issue' => {
             'id' => e1.issue.id,
             'subject' => 'Abstract apples',
-            'tracker' => { 'id' => e1.issue.tracker.id, 'name' => 'Task' }
+            'tracker' => { 'id' => e1.issue.tracker.id, 'name' => 'Task' },
+            'path' => issue_path(e1.issue)
           },
-          'project' => { 'id' => e1.project.id, 'name' => 'Project alpha', 'status' => 1 },
+          'project' => {
+            'id' => e1.project.id,
+            'name' => 'Project alpha',
+            'status' => 1,
+            'path' => project_path(e1.project)
+          },
           'activity' => { 'id' => e1.activity.id, 'name' => 'Development' }
         },
         {
@@ -77,9 +95,15 @@ class T2rRedmineControllerTest < T2r::IntegrationTest
           'issue' => {
             'id' => e2.issue.id,
             'subject' => 'Abstract apples',
-            'tracker' => { 'id' => e2.issue.tracker.id, 'name' => 'Task' }
+            'tracker' => { 'id' => e2.issue.tracker.id, 'name' => 'Task' },
+            'path' => issue_path(e2.issue)
           },
-          'project' => { 'id' => e2.project.id, 'name' => 'Project alpha', 'status' => 1 },
+          'project' => {
+            'id' => e2.project.id,
+            'name' => 'Project alpha',
+            'status' => 1,
+            'path' => project_path(e2.project)
+          },
           'activity' => { 'id' => e2.activity.id, 'name' => 'Development' }
         }
       ]

--- a/test/integration/t2r_toggl_controller_test.rb
+++ b/test/integration/t2r_toggl_controller_test.rb
@@ -73,7 +73,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'duration' => 450,
         'status' => 'pending',
         'errors' => [],
-        'issue' => nil
+        'issue' => nil,
+        'project' => nil
       },
       '19:feed bunny:running' => {
         'key' => '19:feed bunny:running',
@@ -83,7 +84,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'duration' => -1,
         'status' => 'running',
         'errors' => [],
-        'issue' => nil
+        'issue' => nil,
+        'project' => nil
       }
     }
 
@@ -160,20 +162,20 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'comments' => 'Feed bunny',
         'duration' => -1,
         'status' => 'running',
+        'errors' => [],
         'issue' => {
           'id' => issue.id,
           'subject' => issue.subject,
           'tracker' => {
             'id' => issue.tracker.id,
             'name' => issue.tracker.name
-          },
-          'project' => {
-            'id' => issue.project.id,
-            'name' => issue.project.name,
-            'status' => issue.project.status
           }
         },
-        'errors' => []
+        'project' => {
+          'id' => issue.project.id,
+          'name' => issue.project.name,
+          'status' => issue.project.status
+        }
       }
     }
 
@@ -219,7 +221,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'duration' => 300,
         'status' => 'pending',
         'errors' => [],
-        'issue' => nil
+        'issue' => nil,
+        'project' => nil
       }
     }
 
@@ -267,7 +270,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'duration' => 300,
         'status' => 'pending',
         'errors' => [],
-        'issue' => nil
+        'issue' => nil,
+        'project' => nil
       }
     }
 

--- a/test/integration/t2r_toggl_controller_test.rb
+++ b/test/integration/t2r_toggl_controller_test.rb
@@ -3,9 +3,9 @@
 require_relative '../test_helper'
 
 class T2rTogglControllerTest < T2r::IntegrationTest
-  make_my_diffs_pretty!
-
+  include Rails.application.routes.url_helpers
   fixtures :all
+  make_my_diffs_pretty!
 
   def setup
     @user = users(:jsmith)
@@ -174,7 +174,8 @@ class T2rTogglControllerTest < T2r::IntegrationTest
         'project' => {
           'id' => issue.project.id,
           'name' => issue.project.name,
-          'status' => issue.project.status
+          'status' => issue.project.status,
+          'path' => project_path(issue.project)
         }
       }
     }

--- a/test/unit/models/toggl_time_entry_group_test.rb
+++ b/test/unit/models/toggl_time_entry_group_test.rb
@@ -41,6 +41,15 @@ class TogglTimeEntryGroupTest < T2r::TestCase
     assert_equal(record.issue_id, subject.issue_id)
   end
 
+  test '.project' do
+    subject = TogglTimeEntryGroup.new
+    issue = issues(:alpha_001)
+    subject << build_time_entry_record(description: "##{issue.id} Lorem ipsum")
+
+    refute_nil(subject.project)
+    assert_equal(issue.project, subject.project)
+  end
+
   test '.duration' do
     subject = TogglTimeEntryGroup.new
 


### PR DESCRIPTION
As the name suggests, it makes the project labels clickable. The Project URL is generated server-side using `project_path(project)`.

Closes https://github.com/jigarius/toggl2redmine/issues/68