### PR TITLE
Allow BigInt values for Toggl ID

### DIFF
--- a/db/migrate/005_change_toggl_mappings_toggl_id_to_bigint.rb
+++ b/db/migrate/005_change_toggl_mappings_toggl_id_to_bigint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeTogglMappingsTogglIdToBigint < ActiveRecord::Migration[4.2]
+  def up
+    change_column :toggl_mappings, :toggl_id, :bigint
+  end
+end


### PR DESCRIPTION
Fixes #73: As Toggl IDs get bigger, Redmine tables need to be able to accommodate them.

## What's done

* Changes `toggl_mappings.toggl_id` from `int` to `bigint`